### PR TITLE
driver: add enabled reconfigure param

### DIFF
--- a/velodyne_driver/cfg/VelodyneNode.cfg
+++ b/velodyne_driver/cfg/VelodyneNode.cfg
@@ -8,7 +8,8 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("time_offset", double_t,  0, "A manually calibrated offset (in seconds) to add to the timestamp before publication of a message.",
+gen.add("time_offset", double_t,  1, "A manually calibrated offset (in seconds) to add to the timestamp before publication of a message.",
         0.0, -1.0, 1.0)
+gen.add("enabled", bool_t, 2, "Switch to enable and disable lidar packet consumption", True);
 
 exit(gen.generate(PACKAGE, NODE_NAME, PARAMS_NAME))

--- a/velodyne_driver/include/velodyne_driver/driver.h
+++ b/velodyne_driver/include/velodyne_driver/driver.h
@@ -58,6 +58,7 @@ private:
     double rpm;                      ///< device rotation rate (RPMs)
     int cut_angle;                   ///< cutting angle in 1/100°
     double time_offset;              ///< time in seconds added to each velodyne time stamp
+    bool enabled;
   } config_;
 
   boost::shared_ptr<Input> input_;

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -136,6 +136,8 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
                                         TimeStampStatusParam()));
   diag_timer_ = private_nh.createTimer(ros::Duration(0.2), &VelodyneDriver::diagTimerCallback,this);
 
+  config_.enabled = true;
+
   // open Velodyne input device or file
   if (dump_file != "")                  // have PCAP file?
     {
@@ -160,6 +162,13 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
  */
 bool VelodyneDriver::poll(void)
 {
+  if (!config_.enabled) {
+    // If we are not enabled exit once a second to let the caller handle
+    // anything it might need to, such as if it needs to exit.
+    ros::Duration(1).sleep();
+    return true;
+  }
+
   // Allocate a new shared pointer for zero-copy sharing with other nodelets.
   velodyne_msgs::VelodyneScanPtr scan(new velodyne_msgs::VelodyneScan);
 
@@ -232,7 +241,14 @@ void VelodyneDriver::callback(velodyne_driver::VelodyneNodeConfig &config,
               uint32_t level)
 {
   ROS_INFO("Reconfigure Request");
-  config_.time_offset = config.time_offset;
+  if (level & 1)
+  {
+    config_.time_offset = config.time_offset;
+  }
+  if (level & 2)
+  {
+    config_.enabled = config.enabled;
+  }
 }
 
 void VelodyneDriver::diagTimerCallback(const ros::TimerEvent &event)


### PR DESCRIPTION
This will allow polling to be disabled when the device has been disabled
in some way. Specifically this is interesting when the rpm is set to 0
when not is use. This also adds a mask value for the time_offset so that
it won't be touched if it wasn't reconfigured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/velodyne/1)
<!-- Reviewable:end -->
