### PR TITLE
add dyn cfg replace_out_of_range_with_max_range

### DIFF
--- a/velodyne_pointcloud/cfg/CloudNode.cfg
+++ b/velodyne_pointcloud/cfg/CloudNode.cfg
@@ -8,6 +8,8 @@ gen = ParameterGenerator()
 
 gen.add("min_range", double_t, 0, "min range to publish", 0.9, 0.1, 10.0)
 gen.add("max_range", double_t, 0, "max range to publish", 130, 0.1, 200)
+gen.add("replace_out_of_range_with_max_range", bool_t, 0,
+        "replace out-of-range distance values with the max range", False)
 gen.add("view_direction", double_t, 0, "angle defining the center of view",
         0.0, -pi, pi)
 gen.add("view_width", double_t, 0, "angle defining the view width",

--- a/velodyne_pointcloud/cfg/TransformNode.cfg
+++ b/velodyne_pointcloud/cfg/TransformNode.cfg
@@ -17,7 +17,13 @@ gen.add("max_range",
   0, 
   "max range to publish", 
   130, 0.1, 200)
-  
+
+gen.add("replace_out_of_range_with_max_range",
+  pgc.bool_t,
+  0,
+  "replace out-of-range distance values with the max range",
+  False)
+
 gen.add("view_direction", 
   pgc.double_t, 
   0, 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -150,7 +150,7 @@ namespace velodyne_rawdata
     void unpack(const velodyne_msgs::VelodynePacket &pkt, DataContainerBase& data);
     
     void setParameters(double min_range, double max_range, double view_direction,
-                       double view_width);
+                       double view_width, bool replace_out_of_range_with_max_range);
 
     int scansPerPacket() const;
 
@@ -163,6 +163,7 @@ namespace velodyne_rawdata
       double min_range;                ///< minimum range to publish
       int min_angle;                   ///< minimum angle to publish
       int max_angle;                   ///< maximum angle to publish
+      bool replace_out_of_range_with_max_range; ///< replace out of range with max range
       
       double tmp_min_angle;
       double tmp_max_angle;

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -49,7 +49,8 @@ namespace velodyne_pointcloud
   {
   ROS_INFO("Reconfigure Request");
   data_->setParameters(config.min_range, config.max_range, config.view_direction,
-                       config.view_width);
+                       config.view_width,
+                       config.replace_out_of_range_with_max_range);
   }
 
   /** @brief Callback for raw scan messages. */

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -56,7 +56,8 @@ namespace velodyne_pointcloud
   {
     ROS_INFO_STREAM("Reconfigure request.");
     data_->setParameters(config.min_range, config.max_range, 
-                         config.view_direction, config.view_width);
+                         config.view_direction, config.view_width,
+                         config.replace_out_of_range_with_max_range);
     config_.frame_id = tf::resolve(tf_prefix_, config.frame_id);
     ROS_INFO_STREAM("Target frame ID: " << config_.frame_id);
   }

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -399,9 +399,6 @@ inline float SQR(float val) { return val*val; }
                || azimuth_corrected >= config_.min_angle))){
 
             // convert polar coordinates to Euclidean XYZ
-            float distance = tmp.uint * calibration_.distance_resolution_m;
-            distance += corrections.dist_correction;
-            
             float cos_vert_angle = corrections.cos_vert_correction;
             float sin_vert_angle = corrections.sin_vert_correction;
             float cos_rot_correction = corrections.cos_rot_correction;

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -50,10 +50,12 @@ inline float SQR(float val) { return val*val; }
   void RawData::setParameters(double min_range,
                               double max_range,
                               double view_direction,
-                              double view_width)
+                              double view_width,
+                              bool replace_out_of_range_with_max_range)
   {
     config_.min_range = min_range;
     config_.max_range = max_range;
+    config_.replace_out_of_range_with_max_range = replace_out_of_range_with_max_range;
 
     //converting angle parameters into the velodyne reference (rad)
     config_.tmp_min_angle = view_direction + view_width/2;
@@ -195,14 +197,20 @@ inline float SQR(float val) { return val*val; }
         union two_bytes tmp;
         tmp.bytes[0] = block.data[k];
         tmp.bytes[1] = block.data[k+1];
-        if (tmp.bytes[0]==0 &&tmp.bytes[1]==0 ) //no laser beam return
-        {
-          continue;
-        }
 
         float distance = tmp.uint * calibration_.distance_resolution_m;
         distance += corrections.dist_correction;
-        if (!pointInRange(distance)) continue;
+        if (!pointInRange(distance))
+        {
+          if (config_.replace_out_of_range_with_max_range)
+          {
+            distance = config_.max_range;
+          }
+          else
+          {
+            continue;
+          }
+        }
 
         /*condition added to avoid calculating points which are not
           in the interesting defined area (min_angle < area < max_angle)*/
@@ -382,8 +390,18 @@ inline float SQR(float val) { return val*val; }
           float distance = tmp.uint * calibration_.distance_resolution_m;
           distance += corrections.dist_correction;
 
-          // skip the point if out of range
-          if ( !pointInRange(distance)) continue;
+          if (!pointInRange(distance))
+          {
+            if (config_.replace_out_of_range_with_max_range)
+            {
+              distance = config_.max_range;
+            }
+            else
+            {
+              // skip the point if out of range
+              continue;
+            }
+          }
 
           /** correct for the laser rotation as a function of timing during the firings **/
           azimuth_corrected_f = azimuth + (azimuth_diff * ((dsr*VLP16_DSR_TOFFSET) + (firing*VLP16_FIRING_TOFFSET)) / VLP16_BLOCK_TDURATION);


### PR DESCRIPTION
Add a new dynamic configure option to replace out-of-range data with
whatever the maximum range is set to. This is useful for implementing
clearing-on-invalid in a costmap context by setting the max range
beyond the max range used as the maximum obstacle range in a costmap.
The default is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/velodyne/3)
<!-- Reviewable:end -->
